### PR TITLE
generic: Don't dontaudit vendor_persist_camera_prop read denials

### DIFF
--- a/generic/private/app.te
+++ b/generic/private/app.te
@@ -27,7 +27,3 @@
 
 get_prop(appdomain, vendor_persist_dpm_prop)
 get_prop(appdomain, vendor_persist_rcs_prop)
-
-# vendor_persist_camera_prop is not used by 3rd party apps, so don't
-# audit it to suppress the denials
-dontaudit appdomain vendor_persist_camera_prop:file r_file_perms;


### PR DESCRIPTION
This needs to be allowed in order for
I15910154c6df205e6d4e00bfad30a00c9e3d5bee to work. This will be
allowed in device/derp/sepolicy.

Change-Id: Ie22121ee75e048bfa002d8980e15aeab1376f6b4