### PR TITLE
Sepolicy: allow vendor_perfetto_dump to read/write trace_data_file

### DIFF
--- a/generic/private/smart_trace.te
+++ b/generic/private/smart_trace.te
@@ -24,6 +24,39 @@
 # WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 # OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#  Changes from Qualcomm Innovation Center are provided under the following license:
+#  Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted (subject to the limitations in the
+#  disclaimer below) provided that the following conditions are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided
+#        with the distribution.
+#
+#      * Neither the name of Qualcomm Innovation Center, Inc. nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+#  GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+#  HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+#  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+#  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+#  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+#  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+#  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+#  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+#  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 type vendor_perfetto_dump, domain, coredomain;
 type vendor_perfetto_dump_exec, system_file_type, exec_type, file_type;
@@ -31,8 +64,8 @@ type vendor_perfetto_dump_exec, system_file_type, exec_type, file_type;
 init_daemon_domain(vendor_perfetto_dump)
 userdebug_or_eng(`
   set_prop(vendor_perfetto_dump, system_prop)
-  allow vendor_perfetto_dump perfetto_traces_data_file:dir rw_dir_perms;
-  allow vendor_perfetto_dump perfetto_traces_data_file:file { rw_file_perms unlink };
+  allow vendor_perfetto_dump trace_data_file:dir rw_dir_perms;
+  allow vendor_perfetto_dump trace_data_file:file create_file_perms;
   allow vendor_perfetto_dump shell_exec:file { rx_file_perms entrypoint };
   allow vendor_perfetto_dump toolbox_exec:file rx_file_perms;
   allow vendor_perfetto_dump perfetto_exec:file rx_file_perms;
@@ -40,9 +73,6 @@ userdebug_or_eng(`
   allow vendor_perfetto_dump shell:fd use;
   allow vendor_perfetto_dump shell:fifo_file { read write };
 
-  # Allow the service to create new files within /data/misc/perfetto-traces.
-  allow vendor_perfetto_dump perfetto_traces_data_file:file create_file_perms;
-  allow vendor_perfetto_dump perfetto_traces_data_file:dir rw_dir_perms;
   allow traced vendor_perfetto_dump:fd use;
   allow vendor_perfetto_dump traced_consumer_socket:sock_file { write read };
   allow vendor_perfetto_dump traced:unix_stream_socket connectto;


### PR DESCRIPTION
As perfetto_traces_data_file is going to be neverallow, change
to trace_data_file instead.
add allow rules vendor_perfetto_dump to read/write trace_data_file

Change-Id: Ic0569110c81c95cc6756ddc3e551733cd5411ae9
CRs-Fixed: 3194279